### PR TITLE
removing references to old data prep file

### DIFF
--- a/unittest/wordEmbeddings/test_wordEmbeddings.py
+++ b/unittest/wordEmbeddings/test_wordEmbeddings.py
@@ -1,7 +1,6 @@
 import pytest, sys
 sys.path.insert(0, '../../miienlp/embeddings')
 from word_vecs import WordVectors
-from data_prep import WVecDataPreparation
 
 time_series =\
 {"type": "decade",
@@ -33,8 +32,4 @@ data_dir= "test_data/"
 
 class TestWordEmbedding(object):
     def test_combine_text(self):
-        dp = WVecDataPreparation(data_dir, time_series, collection_corpora)
-        time_frame = dp.construct_time_series()
-        df = dp.construct_relevant_file_path_df(time_frame)
-        comb_path = dp.combine_text(df)
-        assert df.head() == ["time_series"]
+        pass


### PR DESCRIPTION
### Overview
Removing references to data prep module, which was an old python class that combined text by decade and/or collection to feed into word embedding models. Now we have a separate repo: DataAggregation to do this and do not need data prep anymore

### Notes
Because of the complexity of word embedding models, I wasn't sure exactly how to test the word embedding class. In the near, future we need to add tests to this script. With data prep removed, there are no further tests in this script. Perhaps Patricia can think of some unit tests that might be able to be written here? 